### PR TITLE
Remove & keep MYMETA. files out of MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -7,8 +7,6 @@ ListUtil.xs
 Makefile.PL
 MANIFEST			This list of files
 multicall.h
-MYMETA.json
-MYMETA.yml
 ppport.h
 README
 t/00version.t

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -9,3 +9,4 @@ cover_db
 ^Scalar-List-Utils
 \.bs$
 \.[oc]$
+^MYMETA\.


### PR DESCRIPTION
This is to exclude the MYMETA* files from the MANIFEST

Currently you get:

Scalar-List-Utils (master)$ perl Makefile.PL
Checking if your kit is complete...
Warning: the following files are missing in your kit:
	MYMETA.json
	MYMETA.yml
Please inform the author.
Writing Makefile for List::Util
Writing MYMETA.yml and MYMETA.json

Removed the files from MANIFEST and added a line to MANIFEST.SKIP so make manifest wouldn't reintroduce them.

