### PR TITLE
Silence a warning properly

### DIFF
--- a/t/refaddr.t
+++ b/t/refaddr.t
@@ -21,7 +21,7 @@ my $t;
 foreach my $r ({}, \$t, [], \*F, sub {}) {
   my $n = "$r";
   $n =~ /0x(\w+)/;
-  my $addr = do { local $^W; hex $1 };
+  my $addr = do { no warnings; hex $1 };
   my $before = ref($r);
   is( refaddr($r), $addr, $n);
   is( ref($r), $before, $n);


### PR DESCRIPTION
"use warnings" provokes a warning but "local $^X" does not silence it,
whereas "no warnings" does.  b810db1350e68a added "use warnings"
introducing the problem.