### PR TITLE
Remove C99 comment, it was failing on C89 compilers. Also, the array …

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -542,7 +542,6 @@ PPCODE:
         if(SvTYPE(SvRV(pair)) != SVt_PVAV)
             croak("Not an ARRAY reference at List::Util::unpack() argument %d", i);
 
-        // TODO: assert pair is an ARRAY ref
         pairav = (AV *)SvRV(pair);
 
         EXTEND(SP, 2);


### PR DESCRIPTION
…ref checking is already being done in the previous line of code.