### PR TITLE
Addresses the two outstanding Kwalitee issues

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,6 @@ WriteMakefile(
     : (
       INSTALLDIRS      => ($] < 5.011 ? q[perl] : q[site]),
       PREREQ_PM        => {'Test::More' => 0,},
-      MIN_PERL_VERSION => '5.006',
       (eval { ExtUtils::MakeMaker->VERSION(6.31) } ? (LICENSE => 'perl') : ()),
       (eval { ExtUtils::MakeMaker->VERSION(6.48) } ? (MIN_PERL_VERSION => '5.006') : ()),
       ( eval { ExtUtils::MakeMaker->VERSION(6.46) } ? (

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,6 +32,7 @@ WriteMakefile(
       PREREQ_PM        => {'Test::More' => 0,},
       MIN_PERL_VERSION => '5.006',
       (eval { ExtUtils::MakeMaker->VERSION(6.31) } ? (LICENSE => 'perl') : ()),
+      (eval { ExtUtils::MakeMaker->VERSION(6.48) } ? (MIN_PERL_VERSION => '5.006') : ()),
       ( eval { ExtUtils::MakeMaker->VERSION(6.46) } ? (
           META_MERGE => {
             'meta-spec' => { version => 2 },

--- a/lib/List/Util.pm
+++ b/lib/List/Util.pm
@@ -7,6 +7,7 @@
 package List::Util;
 
 use strict;
+use warnings;
 require Exporter;
 
 our @ISA        = qw(Exporter);

--- a/lib/List/Util/XS.pm
+++ b/lib/List/Util/XS.pm
@@ -1,5 +1,6 @@
 package List::Util::XS;
 use strict;
+use warnings;
 use List::Util;
 
 our $VERSION = "1.42";       # FIXUP

--- a/lib/Scalar/Util.pm
+++ b/lib/Scalar/Util.pm
@@ -7,6 +7,7 @@
 package Scalar::Util;
 
 use strict;
+use warnings;
 require Exporter;
 
 our @ISA       = qw(Exporter);


### PR DESCRIPTION
Hi Paul,

This adds the min perl version to the dist's metadata, via `MIN_PERL_VERSION` in `Makefile.PL`.

And I added `use warnings` to the modules that didn't already have it.

Cheers,
Neil
