### PR TITLE
Prep for 1.43 release

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,16 @@
+1.43 -- 2016/XX/XX XX:XX:XX
+	[CHANGES]
+	 * Documentation improvements in List::Util
+
+	[BUGFIXES]
+	 * Fix build on C89 compilers (e.g. VC++) (PR24)
+	 * Avoid divide-by-zero exception if product()'s accumulator is IV zero
+	   (RT105415)
+	 * Expurge C99 comments (PR31)
+	 * Remove unused variables in pairmap() (PR32)
+	 * Fix some integer overflows in List::Util (RT101494)
+	 * Silence some compiler warnings in List Util (RT101494)
+
 1.42 -- 2015/04/32 01:25:55
 	[CHANGES]
 	 * Added List::Util::unpairs() - the inverse of pairs()

--- a/lib/List/Util.pm
+++ b/lib/List/Util.pm
@@ -14,7 +14,7 @@ our @EXPORT_OK  = qw(
   all any first min max minstr maxstr none notall product reduce sum sum0 shuffle
   pairs unpairs pairkeys pairvalues pairmap pairgrep pairfirst
 );
-our $VERSION    = "1.42";
+our $VERSION    = "1.43";
 our $XS_VERSION = $VERSION;
 $VERSION    = eval $VERSION;
 

--- a/lib/List/Util/XS.pm
+++ b/lib/List/Util/XS.pm
@@ -2,7 +2,7 @@ package List::Util::XS;
 use strict;
 use List::Util;
 
-our $VERSION = "1.42";       # FIXUP
+our $VERSION = "1.43";       # FIXUP
 $VERSION = eval $VERSION;    # FIXUP
 
 1;

--- a/lib/Scalar/Util.pm
+++ b/lib/Scalar/Util.pm
@@ -16,7 +16,7 @@ our @EXPORT_OK = qw(
   dualvar isdual isvstring looks_like_number openhandle readonly set_prototype
   tainted
 );
-our $VERSION    = "1.42";
+our $VERSION    = "1.43";
 $VERSION   = eval $VERSION;
 
 require List::Util; # List::Util loads the XS

--- a/lib/Sub/Util.pm
+++ b/lib/Sub/Util.pm
@@ -15,7 +15,7 @@ our @EXPORT_OK = qw(
   subname set_subname
 );
 
-our $VERSION    = "1.42";
+our $VERSION    = "1.43";
 $VERSION   = eval $VERSION;
 
 require List::Util; # as it has the XS


### PR DESCRIPTION
I've bumped the version number and populated the Changes file, to help prepare the next release.

I followed the basic format already used in the Changes file, but also indicated the PR # if the change came from a contributor on GitHub and not through RT. There have also been some changes to the dist MANIFEST and Makefile.PL, but I've omitted those from the list of changes.

There are also 4 open PRs right now that I've recently +1ed and could be quickly pulled before this release, if you agree:

 * #33 includes documentation changes only.
 * #34 and #35 are dist related changes only.
 * #36 is also dist related, but also includes adding 'use warnings' to each module. That had previously been suggested in #15 as well. As karenetheridge noted, It should be safe to do given the minimum perl of 5.006.

If you do want to pull any of those those (or any other PRs) before the next release, I'd be happy to update the Changes file accordingly.