### PR TITLE
Fix inline variable declaration for non-C99 compilers

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1020,6 +1020,9 @@ CODE:
     int index;
     SV **args = &PL_stack_base[ax];
     HV *seen;
+#ifdef HV_FETCH_EMPTY_HE
+    HE *he;
+#endif
 
     if(items == 0 || (items == 1 && !SvGAMAGIC(args[0]) && SvOK(args[0]))) {
         /* Optimise for the case of the empty list or a defined nonmagic
@@ -1049,7 +1052,7 @@ CODE:
             else
                 sv_setpvf(keysv, "%"NVgf, SvNV(arg));
 #ifdef HV_FETCH_EMPTY_HE
-            HE* he = hv_common(seen, NULL, SvPVX(keysv), SvCUR(keysv), 0, HV_FETCH_LVALUE | HV_FETCH_EMPTY_HE, NULL, 0);
+            he = hv_common(seen, NULL, SvPVX(keysv), SvCUR(keysv), 0, HV_FETCH_LVALUE | HV_FETCH_EMPTY_HE, NULL, 0);
             if (HeVAL(he))
                 continue;
 
@@ -1090,7 +1093,7 @@ CODE:
                 continue;
             }
 #ifdef HV_FETCH_EMPTY_HE
-            HE* he = hv_common(seen, arg, NULL, 0, 0, HV_FETCH_LVALUE | HV_FETCH_EMPTY_HE, NULL, 0);
+            he = hv_common(seen, arg, NULL, 0, 0, HV_FETCH_LVALUE | HV_FETCH_EMPTY_HE, NULL, 0);
             if (HeVAL(he))
                 continue;
 


### PR DESCRIPTION
MSVC is a real pain... here's a patch to fix another inline variable declaration.