### PR TITLE
Document the behaviour of uniqnum() on NaN

### DIFF
--- a/lib/List/Util.pm
+++ b/lib/List/Util.pm
@@ -517,6 +517,10 @@ are enabled (C<use warnings 'uninitialized';>). In addition, an C<undef> in
 the returned list is coerced into a numerical zero, so that the entire list of
 values returned by C<uniqnum> are well-behaved as numbers.
 
+Note also that multiple IEEE C<NaN> values are treated as duplicates of
+each other, regardless of any differences in their payloads, and despite
+the fact that C<< 0+'NaN' == 0+'NaN' >> yields false.
+
 =head2 uniqstr
 
     my @subset = uniqstr @values


### PR DESCRIPTION
This PR merely documents the current behaviour (which treats all `NaN` values as equal, because it's using a hash to detect uniqueness of string representation).

It's possible that some people would prefer a strict IEEE approach of treating any `NaN` value as unequal to all other `NaN` values (including itself); or even an approach that treats `NaN` values as unequal iff their payloads differ. My guess is that the current behaviour offers least surprise for most people.
