### PR TITLE
ListUtil: Remove impediment to compiling under C++11

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1056,11 +1056,11 @@ CODE:
                 arg = sv_mortalcopy(arg);
 
             if(SvUOK(arg))
-                sv_setpvf(keysv, "%"UVuf, SvUV(arg));
+                sv_setpvf(keysv, "%" UVuf, SvUV(arg));
             else if(SvIOK(arg))
-                sv_setpvf(keysv, "%"IVdf, SvIV(arg));
+                sv_setpvf(keysv, "%" IVdf, SvIV(arg));
             else
-                sv_setpvf(keysv, "%"NVgf, SvNV(arg));
+                sv_setpvf(keysv, "%" NVgf, SvNV(arg));
 #ifdef HV_FETCH_EMPTY_HE
             he = (HE*) hv_common(seen, NULL, SvPVX(keysv), SvCUR(keysv), 0, HV_FETCH_LVALUE | HV_FETCH_EMPTY_HE, NULL, 0);
             if (HeVAL(he))


### PR DESCRIPTION
C++11 changed from earlier versions to require space between the end of
a string literal and a macro, so that a feature can unambiguously be
added to the language.  Starting in g++ 6.2, the compiler emits a
deprecation warning when there isn't a space (presumably so that future
versions can support C++11).

Code and modules included with the Perl core need to be compilable using
C++.  This is so that perl can be embedded in C++ programs. (Actually,
only the hdr files need to be so compilable, but it would be hard to
test that just the hdrs are compilable.)  So we need to accommodate
changes to the C++ language.