### PR TITLE
footnote that outer @_ can be accessed in some blocks, but shouldn't be

### DIFF
--- a/lib/List/Util.pm
+++ b/lib/List/Util.pm
@@ -149,6 +149,9 @@ instead, as it can short-circuit after the first true result.
         # at least one string has more than 10 characters
     }
 
+Note: Due to XS issues the block passed may be able to access the outer @_
+directly. This is not intentional and will break under debugger.
+
 =head2 all
 
     my $bool = all { BLOCK } @list;
@@ -159,6 +162,9 @@ Similar to L</any>, except that it requires all elements of the C<@list> to
 make the C<BLOCK> return true. If any element returns false, then it returns
 false. If the C<BLOCK> never returns false or the C<@list> was empty then it
 returns true.
+
+Note: Due to XS issues the block passed may be able to access the outer @_
+directly. This is not intentional and will break under debugger.
 
 =head2 none
 
@@ -173,6 +179,9 @@ I<Since version 1.33.>
 Similar to L</any> and L</all>, but with the return sense inverted. C<none>
 returns true only if no value in the C<@list> causes the C<BLOCK> to return
 true, and C<notall> returns true only if not all of the values do.
+
+Note: Due to XS issues the block passed may be able to access the outer @_
+directly. This is not intentional and will break under debugger.
 
 =head2 first
 


### PR DESCRIPTION
Footnotes for docs as discussed in IRC.